### PR TITLE
Mark as compatibile with Foundry 0.7.9

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -21,7 +21,7 @@
     }],
   "system": "dnd5e",
   "minimumCoreVersion": "0.6.5",
-  "compatibleCoreVersion": "0.7.7",
+  "compatibleCoreVersion": "0.7.9",
   "url": "https://github.com/HadaIonut/Foundry-mgl",
   "manifest": "https://github.com/HadaIonut/Foundry-mgl/releases/download/v1.1.2/module.json",
   "download": "https://github.com/HadaIonut/Foundry-mgl/releases/download/v1.1.2/module.zip",


### PR DESCRIPTION
With https://github.com/HadaIonut/Foundry-mgl/issues/6 fixed I didn't found any regression when testing on 0.7.**8**.
In  Foundry core 0.7.9 [changelog](https://foundryvtt.com/releases/0.7.9)  I didn't find anything that should break this module but full disclaimer: I was only testing on 0.7.8. 
I can obviously change it to 0.7.8 but I'll leave it to you to decide (and since it is one character change you can simply change it on your own :D )